### PR TITLE
Add article in CITATION and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Computes six functional diversity indices. These are namely,
   Dispersion (FDis), and Rao's entropy (Q) (reviewed in Villéger et al. 2008
   <doi:10.1890/07-1206.1>). Provides efficient, modular, and parallel functions
   to compute functional diversity indices
-  (preprint: <doi:10.32942/osf.io/dg7hw>).
+  (Grenié & Gruson 2023 <doi:10.1111/ecog.06585>).
 License: GPL-3
 Language: en
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Language: en
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Depends: 
     R (>= 2.10)
 Imports:

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,7 +8,6 @@ bibentry(
               person("Hugo", "Gruson")),
   year    = year,
   note    = note,
-  header  = "To cite this package in publications, please use:",
   url     = "https://CRAN.R-project.org/package=fundiversity",
   doi     = "10.5281/zenodo.4761754"
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,5 +1,3 @@
-
-
 year <- ifelse("Date" %in% names(meta), sub("-.*", "", meta$Date), format(Sys.Date(), "%Y"))
 note <- sprintf("R package version %s", meta$Version)
 
@@ -12,15 +10,5 @@ bibentry(
   note    = note,
   header  = "To cite this package in publications, please use:",
   url     = "https://CRAN.R-project.org/package=fundiversity",
-  doi     = "10.5281/zenodo.4761754")
-
-bibentry(
-  bibtype = "manual",
-  title   = "{fundiversity}: Easy Computation of Functional Diversity Indices",
-  author  = c(person("Matthias", "Grenié"),
-              person("Hugo", "Gruson")),
-  year    = year,
-  note    = note,
-  header  = "To cite the development version, please use:",
-  url     = "https://github.com/funecology/fundiversity",
-  doi     = "10.5281/zenodo.4761754")
+  doi     = "10.5281/zenodo.4761754"
+)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,3 +11,16 @@ bibentry(
   url     = "https://CRAN.R-project.org/package=fundiversity",
   doi     = "10.5281/zenodo.4761754"
 )
+
+bibentry(
+  bibtype = "Article",
+  title   = "{fundiversity}: a modular R package to compute functional diversity indices",
+  journal = "Ecography",
+  author  = c(person("Matthias", "Grenié"),
+              person("Hugo", "Gruson")),
+  year    = 2023,
+  doi     = "10.1111/ecog.06585",
+  volume  = 2023,
+  number  = 3,
+  pages   = "e06585"
+)

--- a/man/fundiversity-package.Rd
+++ b/man/fundiversity-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Computes six functional diversity indices. These are namely, Functional Divergence (FDiv), Function Evenness (FEve), Functional Richness (FRic), Functional Richness intersections (FRic_intersect), Functional Dispersion (FDis), and Rao's entropy (Q) (reviewed in Villéger et al. 2008 \doi{10.1890/07-1206.1}). Provides efficient, modular, and parallel functions to compute functional diversity indices (preprint: \doi{10.32942/osf.io/dg7hw}).
+Computes six functional diversity indices. These are namely, Functional Divergence (FDiv), Function Evenness (FEve), Functional Richness (FRic), Functional Richness intersections (FRic_intersect), Functional Dispersion (FDis), and Rao's entropy (Q) (reviewed in Villéger et al. 2008 \doi{10.1890/07-1206.1}). Provides efficient, modular, and parallel functions to compute functional diversity indices (Grenié & Gruson 2023 \doi{10.1111/ecog.06585}).
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Fix #73 

I deleted the double citation of the software. There was one linking to CRAN and one linking to GitHub but I don't believe that's necessary. It would also give us 3 bibentries, which seems a little bit much.